### PR TITLE
Parser for descriptor of normal reactions

### DIFF
--- a/include/readdy/model/Utils.h
+++ b/include/readdy/model/Utils.h
@@ -44,6 +44,9 @@ constexpr inline std::array<const char*, 8> invalidCharacterSequences() {
     return {{"[", "]", "(", ")", "->", "--", ":", "+"}};
 };
 
+static constexpr const char arrow[] = "->";
+static constexpr const char bond[] = "--";
+
 void validateTypeName(const std::string &typeName);
 
 NAMESPACE_END(util)

--- a/include/readdy/model/Utils.h
+++ b/include/readdy/model/Utils.h
@@ -40,8 +40,8 @@ NAMESPACE_BEGIN(util)
 scalar getRecommendedTimeStep(unsigned int N, KernelContext&);
 scalar getMaximumDisplacement(KernelContext&, scalar timeStep);
 
-constexpr inline std::array<const char*, 7> invalidCharacterSequences() {
-    return {{"[", "]", "(", ")", "->", "--", ":"}};
+constexpr inline std::array<const char*, 8> invalidCharacterSequences() {
+    return {{"[", "]", "(", ")", "->", "--", ":", "+"}};
 };
 
 void validateTypeName(const std::string &typeName);

--- a/include/readdy/model/reactions/ReactionRegistry.h
+++ b/include/readdy/model/reactions/ReactionRegistry.h
@@ -97,7 +97,7 @@ public:
 
     bool is_reaction_order2_type(particle_type_type type) const;
 
-    reaction_id add(const std::string &descriptor);
+    reaction_id add(const std::string &descriptor, scalar rate);
 
     reaction_id addConversion(const std::string &name, const std::string &from, const std::string &to, scalar rate);
 

--- a/include/readdy/model/topologies/reactions/SpatialTopologyReaction.h
+++ b/include/readdy/model/topologies/reactions/SpatialTopologyReaction.h
@@ -150,8 +150,6 @@ public:
     SpatialTopologyReaction parse(const std::string &descriptor, scalar rate, scalar radius) const;
 
 private:
-    static constexpr const char arrow[] = "->";
-    static constexpr const char bond[] = "--";
     std::reference_wrapper<const TopologyRegistry> _topology_registry;
 };
 

--- a/readdy/main/model/reactions/ReactionRegistry.cpp
+++ b/readdy/main/model/reactions/ReactionRegistry.cpp
@@ -264,8 +264,8 @@ ReactionRegistry::addFusion(const std::string &name, particle_type_type from1, p
     return id;
 }
 
-ReactionRegistry::reaction_id ReactionRegistry::add(const std::string &descriptor) {
-     // todo
+ReactionRegistry::reaction_id ReactionRegistry::add(const std::string &descriptor, scalar rate) {
+    // todo
     return 0;
 }
 

--- a/readdy/main/model/reactions/ReactionRegistry.cpp
+++ b/readdy/main/model/reactions/ReactionRegistry.cpp
@@ -265,7 +265,7 @@ ReactionRegistry::addFusion(const std::string &name, particle_type_type from1, p
 }
 
 ReactionRegistry::reaction_id ReactionRegistry::add(const std::string &descriptor, scalar rate) {
-    // todo
+    log::trace("begin parsing \"{}\"", descriptor);
     return 0;
 }
 

--- a/readdy/main/model/reactions/ReactionRegistry.cpp
+++ b/readdy/main/model/reactions/ReactionRegistry.cpp
@@ -373,9 +373,7 @@ ReactionRegistry::reaction_id ReactionRegistry::add(const std::string &descripto
         if (rhs.empty()) {
             // numberProducts = 0 -> decay
             assert(numberEducts == 1);
-            log::trace("Found decay reaction from descriptor {}, with name {}, educt {}, rate {}", descriptor, name, educt1, rate);
             return addDecay(name, educt1, rate);
-
         } else {
             auto plusPos = rhs.find('+');
             if (plusPos == rhs.npos) {
@@ -401,8 +399,6 @@ ReactionRegistry::reaction_id ReactionRegistry::add(const std::string &descripto
                     std::tie(product1, product2, productDistance) = treatSideWithPlus(rhs, plusPos, false);
                     assert(educt2 == product2);
                     auto distance = static_cast<scalar>(std::stod(eductDistance));
-                    log::trace("Found enzymatic reaction from descriptor {}, with name {}, catalyst {}, from {}, to {}, rate {}", descriptor, name,
-                               educt2, educt1, product1, rate);
                     return addEnzymatic(name, educt2, educt1, product1, rate, distance);
                 }
             }

--- a/readdy/main/model/reactions/ReactionRegistry.cpp
+++ b/readdy/main/model/reactions/ReactionRegistry.cpp
@@ -40,6 +40,7 @@
 #include <readdy/model/reactions/Decay.h>
 #include <readdy/common/string.h>
 #include <readdy/model/Utils.h>
+#include <regex>
 
 namespace readdy {
 namespace model {
@@ -298,8 +299,115 @@ ReactionRegistry::reaction_id ReactionRegistry::add(const std::string &descripto
         lhs = rutil::str::trim_copy(lhs.substr(colonPos + 1, lhs.npos));
     }
 
+    // some helper functions
+    static std::regex parenthesesContentRegex(R"(\(([^\)]*)\))");
+    static auto getReactionRadius = [](const std::string &s) {
+        std::smatch radiusMatch;
+        if (std::regex_search(s, radiusMatch, parenthesesContentRegex)) {
+            auto radiusString = rutil::str::trim_copy(radiusMatch.str());
+            return rutil::str::trim_copy(radiusString.substr(1, radiusString.size() - 2)); // remove parentheses
+        }
+        throw std::invalid_argument(fmt::format("The term \"{}\" did not contain a pair of parentheses '(*)'", s));
+    };
 
-    return 0;
+    static std::regex bracketsContentRegex(R"(\[([^\)]*)\])");
+    static auto getWeights = [](const std::string &s) {
+        std::smatch weightsMatch;
+        if (std::regex_search(s, weightsMatch, bracketsContentRegex)) {
+            auto weightsString = rutil::str::trim_copy(weightsMatch.str());
+            auto commaPos = weightsString.find(',');
+            if (commaPos == weightsString.npos) {
+                throw std::invalid_argument(fmt::format("The term \"{}\" did not contain a comma ','", s));
+            }
+            auto w1 = rutil::str::trim_copy(weightsString.substr(1, commaPos));
+            auto w2 = rutil::str::trim_copy(weightsString.substr(commaPos+1, weightsString.size() - 2));
+            return std::make_tuple(w1, w2);
+        }
+        throw std::invalid_argument(fmt::format("The term \"{}\" did not contain a pair of brackets '[*]'", s));
+    };
+
+    static auto treatSideWithPlus = [](const std::string &s, std::size_t plusPos, bool searchRadius = false) {
+        auto pType1 = rutil::str::trim_copy(s.substr(0, plusPos));
+        std::string pType2;
+        std::string reactionRadius;
+        if (searchRadius) {
+            auto closingParentheses = s.find(')');
+            if (closingParentheses == s.npos) {
+                throw std::invalid_argument(fmt::format("The side (\"{}\") did not contain a ')'.", s));
+            }
+            pType2 = rutil::str::trim_copy(s.substr(closingParentheses + 1, s.npos));
+            reactionRadius = getReactionRadius(s);
+        } else {
+            pType2 = rutil::str::trim_copy(s.substr(plusPos + 1, s.npos));
+        }
+        return std::make_tuple(pType1, pType2, reactionRadius);
+    };
+
+    std::string w1, w2;
+    scalar weight1 {0.5}, weight2 {0.5};
+    {
+        auto bracketPos = rhs.find('[');
+        if (bracketPos != rhs.npos) {
+            std::tie(w1, w2) = getWeights(rhs);
+            weight1 = static_cast<scalar>(std::stod(w1));
+            weight2 = static_cast<scalar>(std::stod(w2));
+            rhs = rutil::str::trim_copy(rhs.substr(0, bracketPos));
+        }
+    }
+
+    std::size_t numberEducts;
+    std::string educt1, educt2, eductDistance;
+    {
+        auto plusPos = lhs.find('+');
+        if (plusPos == lhs.npos) {
+            numberEducts = 1;
+            educt1 = lhs;
+        } else {
+            numberEducts = 2;
+            std::tie(educt1, educt2, eductDistance) = treatSideWithPlus(lhs, plusPos, true);
+        }
+    }
+
+    std::string product1, product2, productDistance;
+    {
+        if (rhs.empty()) {
+            // numberProducts = 0 -> decay
+            assert(numberEducts == 1);
+            log::trace("Found decay reaction from descriptor {}, with name {}, educt {}, rate {}", descriptor, name, educt1, rate);
+            return addDecay(name, educt1, rate);
+
+        } else {
+            auto plusPos = rhs.find('+');
+            if (plusPos == rhs.npos) {
+                // numberProducts = 1 -> either conversion or fusion
+                product1 = rhs;
+                if (numberEducts == 1) {
+                    // conversion
+                    return addConversion(name, educt1, product1, rate);
+                } else {
+                    // fusion
+                    auto distance = static_cast<scalar>(std::stod(eductDistance));
+                    return addFusion(name, educt1, educt2, product1, rate, distance, weight1, weight2);
+                }
+            } else {
+                // numberProducts = 2 -> either fission or enzymatic
+                if (numberEducts == 1) {
+                    // fission
+                    std::tie(product1, product2, productDistance) = treatSideWithPlus(rhs, plusPos, true);
+                    auto distance = static_cast<scalar>(std::stod(productDistance));
+                    return addFission(name, educt1, product1, product2, rate, distance, weight1, weight2);
+                } else {
+                    // enzymatic
+                    std::tie(product1, product2, productDistance) = treatSideWithPlus(rhs, plusPos, false);
+                    assert(educt2 == product2);
+                    auto distance = static_cast<scalar>(std::stod(eductDistance));
+                    log::trace("Found enzymatic reaction from descriptor {}, with name {}, catalyst {}, from {}, to {}, rate {}", descriptor, name,
+                               educt2, educt1, product1, rate);
+                    return addEnzymatic(name, educt2, educt1, product1, rate, distance);
+                }
+            }
+        }
+    }
 }
 
 ReactionRegistry::reaction_id

--- a/readdy/test/TestKernelContext.cpp
+++ b/readdy/test/TestKernelContext.cpp
@@ -281,13 +281,11 @@ TEST_F(TestKernelContext, ReactionDescriptorInvalidInputs) {
     m::KernelContext ctx;
     ctx.particle_types().add("A", 1., 1.);
     ctx.particle_types().add("B", 1., 1.);
-    std::vector<std::string> inv = {"myinvalid: + A -> B", "noarrow: A B", " : Noname ->", "weights: A + A -> A [0.1, ]"};
+    std::vector<std::string> inv = {"myinvalid: + A -> B", "noarrow: A B", " : Noname ->", "weights: A + A -> A [0.1, ]", "blub: A (3)+ A -> B"};
     for (const auto &i : inv) {
-        auto addInv = [&ctx, &i]() {
-            ctx.reactions().add(i, 42.);
-        };
-        EXPECT_ANY_THROW(addInv());
+        EXPECT_ANY_THROW(ctx.reactions().add(i, 42.));
     }
+    ctx.configure();
     EXPECT_EQ(ctx.reactions().n_order1(), 0);
     EXPECT_EQ(ctx.reactions().n_order2(), 0);
 }

--- a/readdy/test/TestKernelContext.cpp
+++ b/readdy/test/TestKernelContext.cpp
@@ -270,7 +270,18 @@ TEST_F(TestKernelContext, ReactionDescriptorAddReactions) {
 }
 
 TEST_F(TestKernelContext, ReactionDescriptorInvalidInputs) {
-
+    m::KernelContext ctx;
+    ctx.particle_types().add("A", 1., 1.);
+    ctx.particle_types().add("B", 1., 1.);
+    std::vector<std::string> inv = {"myinvalid: + A -> B", "noarrow: A B", " : Noname ->", "weights: A + A -> A [0.1, ]"};
+    for (const auto &i : inv) {
+        auto addInv = [&ctx, &i]() {
+            ctx.reactions().add(i, 42.);
+        };
+        EXPECT_ANY_THROW(addInv());
+    }
+    EXPECT_EQ(ctx.reactions().n_order1(), 0);
+    EXPECT_EQ(ctx.reactions().n_order2(), 0);
 }
 
 INSTANTIATE_TEST_CASE_P(TestKernelContext, TestKernelContextWithKernels,

--- a/readdy/test/TestKernelContext.cpp
+++ b/readdy/test/TestKernelContext.cpp
@@ -193,13 +193,17 @@ TEST_P(TestKernelContextWithKernels, PotentialOrder1Map) {
 }
 
 TEST_F(TestKernelContext, ReactionDescriptorAddReactions) {
-    m::KernelContext ctx;
-    ctx.particle_types().add("A", 1., 1.);
-    ctx.particle_types().add("B", 1., 1.);
-    ctx.particle_types().add("C", 1., 1.);
+    const auto prepareCtx = [](m::KernelContext &ctx, const std::string& descriptor, readdy::scalar rate){
+        ctx.particle_types().add("A", 1., 1.);
+        ctx.particle_types().add("B", 1., 1.);
+        ctx.particle_types().add("C", 1., 1.);
+        ctx.reactions().add(descriptor, rate);
+        ctx.configure();
+    };
     {
+        m::KernelContext ctx;
         auto decay = "mydecay:A->";
-        ctx.reactions().add(decay, 2.);
+        prepareCtx(ctx, decay, 2.);
         const auto &r = ctx.reactions().order1_by_name("mydecay");
         ASSERT_NE(r, nullptr);
         EXPECT_EQ(r->getType(), m::reactions::ReactionType::Decay);
@@ -209,8 +213,9 @@ TEST_F(TestKernelContext, ReactionDescriptorAddReactions) {
         EXPECT_EQ(r->getRate(), 2.);
     }
     {
+        m::KernelContext ctx;
         auto conversion = "myconv: A -> B";
-        ctx.reactions().add(conversion, 3.);
+        prepareCtx(ctx, conversion, 3.);
         const auto &r = ctx.reactions().order1_by_name("myconv");
         ASSERT_NE(r, nullptr);
         EXPECT_EQ(r->getType(), m::reactions::ReactionType::Conversion);
@@ -221,8 +226,9 @@ TEST_F(TestKernelContext, ReactionDescriptorAddReactions) {
         EXPECT_EQ(r->getRate(), 3.);
     }
     {
+        m::KernelContext ctx;
         auto fusion = "myfus: B +(1.2) B -> C [0.5, 0.5]";
-        ctx.reactions().add(fusion, 4.);
+        prepareCtx(ctx, fusion, 4.);
         const auto &r = ctx.reactions().order2_by_name("myfus");
         ASSERT_NE(r, nullptr);
         EXPECT_EQ(r->getType(), m::reactions::ReactionType::Fusion);
@@ -237,8 +243,9 @@ TEST_F(TestKernelContext, ReactionDescriptorAddReactions) {
         EXPECT_EQ(r->getRate(), 4.);
     }
     {
+        m::KernelContext ctx;
         auto fission = "myfiss: B -> C +(3.0) B [0.1, 0.9]";
-        ctx.reactions().add(fission, 5.);
+        prepareCtx(ctx, fission, 5.);
         const auto &r = ctx.reactions().order1_by_name("myfiss");
         ASSERT_NE(r, nullptr);
         EXPECT_EQ(r->getType(), m::reactions::ReactionType::Fission);
@@ -253,8 +260,9 @@ TEST_F(TestKernelContext, ReactionDescriptorAddReactions) {
         EXPECT_EQ(r->getRate(), 5.);
     }
     {
+        m::KernelContext ctx;
         auto enzymatic = "myenz:A +(1.5) C -> B + C";
-        ctx.reactions().add(enzymatic, 6.);
+        prepareCtx(ctx, enzymatic, 6.);
         const auto &r = ctx.reactions().order2_by_name("myenz");
         ASSERT_NE(r, nullptr);
         EXPECT_EQ(r->getType(), m::reactions::ReactionType::Enzymatic);

--- a/wrappers/python/src/cxx/api/ExportKernelContext.cpp
+++ b/wrappers/python/src/cxx/api/ExportKernelContext.cpp
@@ -31,6 +31,9 @@
  */
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
 #include <readdy/model/KernelContext.h>
 
 namespace py = pybind11;
@@ -165,6 +168,10 @@ void exportKernelContext(py::module &module) {
                           [](KernelContext &self, KernelContext::PeriodicBoundaryConditions pbc) {
                               self.periodicBoundaryConditions() = pbc;
                           })
+            .def_property_readonly("dist_squared_fun", &KernelContext::distSquaredFun)
+            .def_property_readonly("fix_position_fun", &KernelContext::fixPositionFun)
+            .def_property_readonly("shortest_difference_fun", &KernelContext::shortestDifferenceFun)
+            .def("configure", &KernelContext::configure, "debug_output"_a = true)
             .def("bounding_box_vertices", &KernelContext::getBoxBoundingVertices)
             .def("calculate_max_cutoff", &KernelContext::calculateMaxCutoff)
             .def_property("record_reactions_with_positions",
@@ -174,10 +181,10 @@ void exportKernelContext(py::module &module) {
                           [](const KernelContext &self) { return self.recordReactionCounts(); },
                           [](KernelContext &self, bool value) { self.recordReactionCounts() = value; })
             .def("set_kernel_configuration", &KernelContext::setKernelConfiguration)
-            .def("particle_types", [](KernelContext &self) { return self.particle_types(); }, rvp::reference_internal)
-            .def("reactions", [](KernelContext &self) { return self.reactions(); }, rvp::reference_internal)
-            .def("potentials", [](KernelContext &self) { return self.potentials(); }, rvp::reference_internal)
-            .def("topologies", [](KernelContext &self) { return self.topology_registry(); }, rvp::reference_internal)
-            .def("compartments", [](KernelContext &self) { return self.compartments(); }, rvp::reference_internal);
+            .def("particle_types", [](KernelContext &self) -> ParticleTypeRegistry&  { return self.particle_types(); }, rvp::reference_internal)
+            .def("reactions", [](KernelContext &self) -> ReactionRegistry& { return self.reactions(); }, rvp::reference_internal)
+            .def("potentials", [](KernelContext &self) -> PotentialRegistry& { return self.potentials(); }, rvp::reference_internal)
+            .def("topologies", [](KernelContext &self) -> TopologyRegistry& { return self.topology_registry(); }, rvp::reference_internal)
+            .def("compartments", [](KernelContext &self) -> CompartmentRegistry&  { return self.compartments(); }, rvp::reference_internal);
 
 }

--- a/wrappers/python/src/python/readdy/prototyping/tests/test_model.py
+++ b/wrappers/python/src/python/readdy/prototyping/tests/test_model.py
@@ -37,19 +37,18 @@ class TestModel(ReaDDyTestCase):
         self.ctx = self.kernel.get_kernel_context()
         self.model = self.kernel.get_kernel_state_model()
         self.progs = self.kernel.get_action_factory()
-        self.pots = self.kernel.get_potential_factory()
 
     def test_kernel_context_kbt(self):
         self.ctx.kbt = 5.0
         np.testing.assert_equal(self.ctx.kbt, 5.0)
 
     def test_kernel_context_box_size(self):
-        self.ctx.set_box_size(cmn.Vec(5, 5, 5))
-        np.testing.assert_equal(self.ctx.get_box_size(), cmn.Vec(5, 5, 5))
+        self.ctx.box_size = [5., 5., 5.]
+        np.testing.assert_equal(self.ctx.box_size, [5., 5., 5.])
 
     def test_kernel_context_periodic_boundary(self):
-        self.ctx.periodic_boundary = [True, False, True]
-        np.testing.assert_equal(self.ctx.periodic_boundary, [True, False, True])
+        self.ctx.pbc = [True, False, True]
+        np.testing.assert_equal(self.ctx.pbc, [True, False, True])
 
     def test_kernel_context_register_particle_type(self):
         self.ctx.particle_types().add("A", 13.0, 17.0, 0)
@@ -57,10 +56,10 @@ class TestModel(ReaDDyTestCase):
         np.testing.assert_equal(self.ctx.particle_types().radius_of("A"), 17.0)
 
     def test_kernel_context_fix_position_fun(self):
-        self.ctx.set_box_size(cmn.Vec(1, 1, 1))
-        self.ctx.periodic_boundary = [True, True, True]
+        self.ctx.box_size = [1, 1, 1]
+        self.ctx.pbc = [True, True, True]
         self.ctx.configure()
-        fix_pos = self.ctx.get_fix_position_fun()
+        fix_pos = self.ctx.fix_position_fun
         v_outside = cmn.Vec(4, 4, 4)
         fix_pos(v_outside)
         v_inside = cmn.Vec(.1, .1, .1)
@@ -69,10 +68,10 @@ class TestModel(ReaDDyTestCase):
         np.testing.assert_equal(v_inside, cmn.Vec(.1, .1, .1))
 
     def test_kernel_context_shortest_difference(self):
-        self.ctx.set_box_size(cmn.Vec(2, 2, 2))
-        self.ctx.periodic_boundary = [True, True, True]
+        self.ctx.box_size = [2, 2, 2]
+        self.ctx.pbc = [True, True, True]
         self.ctx.configure()
-        diff = self.ctx.get_shortest_difference_fun()
+        diff = self.ctx.shortest_difference_fun
         np.testing.assert_equal(diff(cmn.Vec(0, 0, 0), cmn.Vec(1, 0, 0)), cmn.Vec(1, 0, 0),
                                 err_msg="both vectors were already inside the domain")
         np.testing.assert_equal(diff(cmn.Vec(0, 0, 0), cmn.Vec(-1.5, 0, 0)), cmn.Vec(.5, 0, 0),
@@ -80,15 +79,15 @@ class TestModel(ReaDDyTestCase):
                                         "position update to (.5, 0, 0)")
 
     def test_kernel_context_dist_squared_fun(self):
-        self.ctx.set_box_size(cmn.Vec(2, 2, 2))
-        self.ctx.periodic_boundary = [True, True, True]
-        dist = self.ctx.get_dist_squared_fun()
+        self.ctx.box_size = [2., 2., 2.]
+        self.ctx.pbc = [True, True, True]
+        dist = self.ctx.dist_squared_fun
         np.testing.assert_equal(dist(cmn.Vec(0, 0, 0), cmn.Vec(1, 0, 0)), 1.0)
         np.testing.assert_equal(dist(cmn.Vec(-.5, 0, 0), cmn.Vec(-1.5, 0, 0)), 1.0)
 
     def test_potential_order_1(self):
-        self.ctx.set_box_size(cmn.Vec(2, 2, 2))
-        self.ctx.periodic_boundary = [True, True, True]
+        self.ctx.box_size = [2., 2., 2.]
+        self.ctx.pbc = [True, True, True]
         self.model.get_particle_data().clear()
 
         class MyPot1(pr.PotentialOrder1):
@@ -111,7 +110,7 @@ class TestModel(ReaDDyTestCase):
                 return kbt
 
         self.ctx.particle_types().add("A", 1.0, 1.0, 0)
-        pot = MyPot1("A")
+        pot = MyPot1(self.ctx.particle_types().id_of("A"))
         self.ctx.potentials().add_external_order1(pot)
         particles = [pr.Particle(0, 0, .5, self.ctx.particle_types().id_of("A"))]
         add_particles_program = self.progs.create_add_particles(particles)
@@ -130,8 +129,8 @@ class TestModel(ReaDDyTestCase):
             next(it)
 
     def test_potential_order_2(self):
-        self.ctx.set_box_size(cmn.Vec(2, 2, 2))
-        self.ctx.periodic_boundary = [True, True, True]
+        self.ctx.box_size = [2, 2, 2]
+        self.ctx.pbc = [True, True, True]
         self.model.get_particle_data().clear()
 
         class MyPot2(pr.PotentialOrder2):
@@ -155,7 +154,7 @@ class TestModel(ReaDDyTestCase):
 
         self.ctx.particle_types().add("A", 1.0, 1.0, 0)
         self.ctx.particle_types().add("B", 1.0, 1.0, 0)
-        pot = MyPot2("A", "B")
+        pot = MyPot2(self.ctx.particle_types().id_of("A"), self.ctx.particle_types().id_of("B"))
         self.ctx.potentials().add_external_order2(pot)
         particles = [pr.Particle(0, 0, 0, self.ctx.particle_types().id_of("A")),
                      pr.Particle(1, 1, 1, self.ctx.particle_types().id_of("B"))]
@@ -179,18 +178,13 @@ class TestModel(ReaDDyTestCase):
         with np.testing.assert_raises(StopIteration):
             next(it)
 
-    def test_potential_factory(self):
+    def test_potential_registry(self):
         self.ctx.particle_types().add("A", 1.0, 1.0, 0)
         self.ctx.particle_types().add("B", 1.0, 1.0, 0)
-        cube_pot = self.pots.create_cube_potential("A", 1, cmn.Vec(0, 0, 0), cmn.Vec(1, 1, 1), True)
-        np.testing.assert_equal(cube_pot.get_name(), "Cube")
-
-        repulsion_pot = self.pots.create_harmonic_repulsion("A", "B", 10)
-        np.testing.assert_equal(repulsion_pot.get_name(), "HarmonicRepulsion")
-
-        weak_interaction_pot = self.pots.create_weak_interaction("A", "B", 0, 0, 0, 0)
-        np.testing.assert_equal(weak_interaction_pot.get_name(), "WeakInteractionPiecewiseHarmonic")
-
+        cube_pot_id = self.ctx.potentials().add_box("A", 1, cmn.Vec(0, 0, 0), cmn.Vec(1, 1, 1), True)
+        repulsion_pot_id = self.ctx.potentials().add_harmonic_repulsion("A", "B", 10)
+        weak_interaction_pot_id = self.ctx.potentials().add_weak_interaction_piecewise_harmonic("A", "B", 0, 0, 0, 0)
+        np.testing.assert_(cube_pot_id != repulsion_pot_id != weak_interaction_pot_id)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Normal reactions can be added to the context with a descriptor string, e.g.
```cpp
readdy::model::KernelContext ctx;
auto fusion = "myfus: A +(2) B -> C [0.4, 0.6]"
scalar rate = 42.;
ctx.reactions().add(fusion, rate)
```
This will create a `Fusion` reaction named `myfus` in which `A` and `B` will fuse with rate 42 to a `C` particle. The reaction radius is denoted in the parentheses after the `+`. For `Fusion` and `Fission` reactions one can specify weights in brackets. This is optional, they will default to `0.5`.