### PR TITLE
Possible travis fix/workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
 - linux
 - osx
 
-osx_image: xcode9.4
+osx_image: xcode11
 
 addons:
   apt:

--- a/include/readdy/api/Saver.h
+++ b/include/readdy/api/Saver.h
@@ -4,15 +4,15 @@
 
 #pragma once
 
-#ifdef __cpp_lib_filesystem
-#define CPP_FS 1
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
+//#ifdef __cpp_lib_filesystem
+//#define CPP_FS 1
+//#include <filesystem>
+//namespace fs = std::filesystem;
+//#else
 #define CPP_FS 0
 #include <readdy/common/filesystem.h>
 namespace fs = readdy::util::fs;
-#endif
+//#endif
 
 #include <memory>
 #include <type_traits>


### PR DESCRIPTION
Travis build of python 3.7 works with xcode11. However the combination macOS 10.14/xcode11 does not have std::filesystem implemented in the libc++. Travis only has macOS 10.14, std::filesystem will only be available on macOS 10.15 ... Hence the forced readdy::filesystem.